### PR TITLE
Add optional arguments using argparse.

### DIFF
--- a/import_any.py
+++ b/import_any.py
@@ -94,7 +94,7 @@ def fixts(ts):
     global last_ts
     global last_day
     if ts == last_ts:
-	return last_day
+        return last_day
     d =  fromtimestamp(int(ts)).strftime("%Y-%m-%d")
     last_ts = ts
     last_day = d

--- a/import_any.py
+++ b/import_any.py
@@ -108,10 +108,11 @@ def get_data(f):
     for rec in reader(f):
         rec['ts'] = rec['ts'].split(".")[0]
         rec['day'] = fixts(rec['ts'])
-        rec['orig_h'] = rec.pop("id.orig_h")
-        rec['orig_p'] = rec.pop("id.orig_p")
-        rec['resp_h'] = rec.pop("id.resp_h")
-        rec['resp_p'] = rec.pop("id.resp_p")
+        if 'id.orig_h' in rec:
+            rec['orig_h'] = rec.pop("id.orig_h")
+            rec['orig_p'] = rec.pop("id.orig_p")
+            rec['resp_h'] = rec.pop("id.resp_h")
+            rec['resp_p'] = rec.pop("id.resp_p")
         if 'service' in rec:
             rec['service'] = rec['service'].split(",")
         if 'remote_location.country_code' in rec:


### PR DESCRIPTION
Building up on #2, this adds some optional command line arguments using argparse:

```
usage: import_any.py [-h] [-f] [-z CMD] [-e ENDPOINT] TABLE FILE [FILE ...]

This script allows to import Bro logs into a clickhouse database.

positional arguments:
  TABLE        table to insert into
  FILE         file(s) to import

optional arguments:
  -h, --help   show this help message and exit
  -f           force insert, although already done
  -z CMD       command to extract logs (default: zcat)
  -e ENDPOINT  database endpoint (default: http://localhost:8123)
```