### PR TITLE
Removed extra comma

### DIFF
--- a/schemas/conn.sql
+++ b/schemas/conn.sql
@@ -22,6 +22,6 @@ resp_pkts UInt64,
 resp_ip_bytes UInt64,
 orig_cc FixedString(2),
 resp_cc FixedString(2),
-peer String,
+peer String
 )
 ENGINE = MergeTree(day,halfMD5(uid), (day,halfMD5(uid), uid), 8192);


### PR DESCRIPTION
If you try to run the statement with the comma, you will get:

```
Code: 62, e.displayText() = DB::Exception: Syntax error: failed at position 637 (line 26, col 1): )
```