### PR TITLE
add schema for kerberos

### DIFF
--- a/schemas/kerberos.sql
+++ b/schemas/kerberos.sql
@@ -1,0 +1,25 @@
+create table kerberos (
+day Date DEFAULT toDate(ts),
+ts DateTime,
+uid String,
+orig_h String,
+orig_p UInt16,
+resp_h String,
+resp_p UInt16,
+request_type Enum8('AS'=0, 'TGS'=1),
+client String,
+service String,
+success Nullable(Enum8('T'=0, 'F'=1)),
+error_msg Nullable(String),
+from Nullable(Float32),
+till Float32,
+cipher Nullable(String),
+forwardable Enum8('T'=0, 'F'=1),
+renewable Nullable(Enum8('T'=0, 'F'=1)),
+client_cert_subject Nullable(String),
+client_cert_fuid Nullable(String),
+server_cert_subject Nullable(String),
+server_cert_fuid Nullable(String),
+schema UInt32
+)
+ENGINE = MergeTree(day,sipHash64(uid), (day,sipHash64(uid), uid), 8192);


### PR DESCRIPTION
This won't work as is. This is because the `conn` schema [defines a `service` field as an array of strings](https://github.com/ncsa/bro-clickhouse/blob/c9d44c1f0dff7eec6d52006f7ecd173c91fc1c24/schemas/conn.sql#L10) and the import script turns the `service` field from a [string into an array](https://github.com/ncsa/bro-clickhouse/blob/c9d44c1f0dff7eec6d52006f7ecd173c91fc1c24/import_any.py#L123).

I'm not exactly sure why that field is turned into an array.

The potential solutions I see are to either pass the `table` name into `get_data` so that the `service` field can be handled differently based on the file type or change the `conn` schema to not use an array (but I don't know the consequences of that).